### PR TITLE
Named matches fail on Ruby 1.8.7

### DIFF
--- a/lib/puppet/parser/functions/pget_filename.rb
+++ b/lib/puppet/parser/functions/pget_filename.rb
@@ -6,8 +6,7 @@ Returns the filename of a path
     raise(Puppet::ParseError, "pget_filename(): Wrong number of arguments " +
         "given (#{args.size} for 1") if args.size != 1
     path = args[0]
-    filename = /.*\/(?<filename>[^\/#?]+)/.match(path)[:filename]
+    filename = File.basename(URI.parse(path).path)
     return filename
   end
 end
-


### PR DESCRIPTION
Named matches don't work on Ruby 1.8.7, still the most used Ruby version by puppet installs.
