### PR TITLE
Support for overriding destination filename

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@ define pget (
     }
     $cmd = "${base_cmd}${header_cmd}${pass_cmd}\$wc.DownloadFile('${source}','${target_file}')"
     debug("About to execute command ${cmd}")
-    exec{"Download-${filename}":
+    exec{"Download-${filename}-to-${target}":
       provider  => powershell,
       command   => $cmd,
       unless    => "if(Test-Path -Path \"${target_file}\" ){ exit 0 }else{exit 1}",


### PR DESCRIPTION
Adds support to specify the filename of the downloaded file.

Useful when downloading from servers that does redirect.

Example: `http://mvn/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.apache&a=stringutils&v=1.20&e=jar` will result in the desintation file being `redirect`.

Now you can specify `targetfilename` as `stringutils.jar`.

Example usage:

```
 pget{'Download puppet':
   source  => "http://downloads.puppetlabs.com/windows/puppet-3.4.1.msi",
   target  => "C:/software",
   targetfilename => "my-puppet-install.msi",
   username=> "myuser",
   password=> "password1'
 }
```
