### PR TITLE
Feature proposal: overwrite target file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+### 10/08/2014
+Proposed feature to allow overwriting the target file
+
 ### 07/21/2014
-#Feature added to allow for targetfilename to be specified
+Feature added to allow for targetfilename to be specified
 
 ### 07/10/2014
 Add license file

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,12 @@
 # [*target*]
 #   The stage directory where the file is to be downloaded
 # [*targetfilename*]
-#   The filename of the downloaded file. Overrides the filename provided by the server.
+#   The filename of the downloaded file. Overrides the filename provided by
+#   the server.
+# [*overwrite*]
+#   Optional. Set to true if [*source*] is to be downloaded and the target
+#   file overwritten, even if already present
+#   Default is false.
 # [*username*]
 #   If authentications is required provide both username and password
 # [*password*]
@@ -22,23 +27,23 @@
 # === Examples
 #
 #  pget{'Download puppet':
-#source  => "http://downloads.puppetlabs.com/windows/puppet-3.4.1.msi",
-#target  => "C:/software",
+# source  => "http://downloads.puppetlabs.com/windows/puppet-3.4.1.msi",
+# target  => "C:/software",
 #}
-
+#
 # pget{'Download puppet':
 #   source  => "http://downloads.puppetlabs.com/windows/puppet-3.4.1.msi",
 #   target  => "C:/software",
 #   username=> "myuser",
 #   password=> "password1'
-# }
+#}
 # pget{'Download puppet':
 #   source  => "http://downloads.puppetlabs.com/windows/puppet-3.4.1.msi",
 #   target  => "C:/software",
 #   targetfilename => "my-puppet-install.msi",
 #   username=> "myuser",
 #   password=> "password1'
-# }
+#}
 #
 #
 # === Copyright
@@ -46,44 +51,58 @@
 # Copyright 2013 Travis F, unless otherwise noted.
 #
 define pget (
-  $source,                 #: the source file location, supports local files, http://, https://, ftp://
-  $target         = undef, #: the target stage directory,
-  $targetfilename = undef, #: desired filename, will be infered by the source if not defined.
-  $username       = undef, #: Username to be passed
-  $password       = undef, #: password needed,
-  $timeout        = 300,   #: timeout
-  $headerHash     = undef, #: additional has parameters for the download of the file, i.e. user-agent, Cookie
-  ){
-
+  $source, # : the source file location, supports local files, http://, https://, ftp://
+  $target         = undef, # : the target stage directory,
+  $targetfilename = undef, # : desired filename, will be infered by the source if not defined.
+  $username       = undef, # : Username to be passed
+  $password       = undef, # : password needed,
+  $timeout        = 300,   # : timeout
+  $headerHash     = undef, # : additional has parameters for the download of the file, i.e. user-agent, Cookie
+  $overwrite      = false, # : if the target file should be overwritten (if already present)
+  ) {
   validate_string($source)
-  validate_re($source,['^s?ftp:','^https?:','^ftps?:','^puppet:'])
+  validate_re($source, [
+    '^s?ftp:',
+    '^https?:',
+    '^ftps?:',
+    '^puppet:'])
 
-  if $::operatingsystem != 'windows'{
+  if $::operatingsystem != 'windows' {
     fail("Unsupported OS ${::operatingsystem}")
   }
-  
+
   if $targetfilename != undef {
-     $filename = $targetfilename
+    $filename = $targetfilename
   } else {
-	   $filename = pget_filename($source)
+    $filename = pget_filename($source)
   }
-  
+
   $target_file = "${target}/${filename}"
 
+  if $overwrite {
+    $unlessClause = ''
+  } else {
+    $unlessClause = "if(Test-Path -Path \"${target_file}\" ){ exit 0 }else{exit 1}"
+  }
+
   if $source =~ /^puppet/ {
-    file{"Download-${filename}":
-      ensure  => file,
-      path    => $target_file,
-      source  => $source,
+    file { "Download-${filename}":
+      ensure => file,
+      path   => $target_file,
+      source => $source,
     }
-  }else{
-    validate_re($source,['^s?ftp:','^https?:','^ftps?:'])
+  } else {
+    validate_re($source, [
+      '^s?ftp:',
+      '^https?:',
+      '^ftps?:'])
     $base_cmd = '$wc = New-Object System.Net.WebClient;'
+
     if $username or $password {
       validate_string($password)
-      validate_re($password,['(\w|\W)+'],'Password must be supplied')
+      validate_re($password, ['(\w|\W)+'], 'Password must be supplied')
       validate_string($username)
-      validate_re($username,['(\w|\W)+'],'Username must be supplied')
+      validate_re($username, ['(\w|\W)+'], 'Username must be supplied')
       $pass_cmd = "\$wc.Credentials = New-Object System.Net.NetworkCredential('${username}','${password}');"
     }
 
@@ -93,12 +112,12 @@ define pget (
     }
     $cmd = "${base_cmd}${header_cmd}${pass_cmd}\$wc.DownloadFile('${source}','${target_file}')"
     debug("About to execute command ${cmd}")
-    exec{"Download-${filename}-to-${target}":
-      provider  => powershell,
-      command   => $cmd,
-      unless    => "if(Test-Path -Path \"${target_file}\" ){ exit 0 }else{exit 1}",
-      timeout   => $timeout,
+
+    exec { "Download-${filename}-to-${target}":
+      provider => powershell,
+      command  => $cmd,
+      unless   => $unlessClause,
+      timeout  => $timeout,
     }
   }
-
 }

--- a/spec/defines/pget_spec.rb
+++ b/spec/defines/pget_spec.rb
@@ -95,4 +95,28 @@ describe 'pget' do
              )
     }
   end
+  describe 'Download file and overwrite even if target file is already present' do
+    let(:params){{:password => 'testme',:username => 'testuser',:source => 'https://downloads.puppetlabs.com/windows/puppet-3.4.1.msi',:target => targetPath, :targetfilename => 'puppet.msi', :overwrite => 'true'}}
+    it{
+      should contain_exec("Download-puppet.msi-to-#{targetPath}").with(
+                 {
+                 'provider' => 'powershell',
+                 'command' => "\$wc = New-Object System.Net.WebClient;\$wc.Credentials = New-Object System.Net.NetworkCredential('testuser','testme');\$wc.DownloadFile('https://downloads.puppetlabs.com/windows/puppet-3.4.1.msi','C:/software/puppet.msi')",
+                 'unless' => ''
+                 }
+             )
+    }
+  end
+  describe 'Do not download file if target file is already present' do
+    let(:params){{:password => 'testme',:username => 'testuser',:source => 'https://downloads.puppetlabs.com/windows/puppet-3.4.1.msi',:target => targetPath, :targetfilename => 'puppet.msi'}}
+    it{
+      should contain_exec("Download-puppet.msi-to-#{targetPath}").with(
+                 {
+                 'provider' => 'powershell',
+                 'command' => "\$wc = New-Object System.Net.WebClient;\$wc.Credentials = New-Object System.Net.NetworkCredential('testuser','testme');\$wc.DownloadFile('https://downloads.puppetlabs.com/windows/puppet-3.4.1.msi','C:/software/puppet.msi')",
+                 'unless' => "if(Test-Path -Path \"#{targetPath}/puppet.msi\" ){ exit 0 }else{exit 1}"
+                 }
+             )
+    }
+  end
 end


### PR DESCRIPTION
I would like to add a feature allowing the target file to be overwritten and thus the remote file to be re-downloaded, even if the target file exists. The current implementation skips downloading the remote file if the target file is already present.

I have created two new specs, but Ruby isn't my primary language, so I'm not quite sure I got it right (the specs ran successfully, though). My company firewall doesn't allow me to push to GitHub, so I had to copy my changes to the GitHub web editor. Hope I got everything over.

Regards
Anders L.