### PR TITLE
added parameter $ignore_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Hash containing header information such as user-agent, cookie and others, direct
 ####`overwrite`
 Whether to force the download even if file already exists
 
+####`ingore_proxy`
+Ignore the system proxy when set to `true`.
+
 ##Reference
 [WebClient API](http://msdn.microsoft.com/en-us/library/system.net.webclient.headers(v=vs.110).aspx)
   

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,9 +58,11 @@ define pget (
   $password       = undef, #: password needed,
   $timeout        = 300,   #: timeout
   $headerHash     = undef, #: additional has parameters for the download of the file, i.e. user-agent, Cookie
-  $overwrite      = false, # : if the target file should be overwritten (if already present)
+  $overwrite      = false, #: if the target file should be overwritten (if already present)
+  $ignore_proxy   = false, #: check if system proxy should ignored 
 ) {
   validate_string($source)
+  validate_bool($ignore_proxy)
   validate_re($source, [
     '^s?ftp:',
     '^https?:',
@@ -91,7 +93,11 @@ define pget (
     }
   } else{
     validate_re($source,['^s?ftp:','^https?:','^ftps?:'])
-    $_base_cmd = '$wc = New-Object System.Net.WebClient;'
+    if $ignore_proxy == true {
+      $_base_cmd = '$wc = New-Object System.Net.WebClient;$wc.Proxy = [System.Net.GlobalProxySelection]::GetEmptyWebProxy();'
+    } else {
+      $_base_cmd = '$wc = New-Object System.Net.WebClient;'
+    }
 
     if $username or $password {
       validate_string($password)


### PR DESCRIPTION
Previously pget used the system proxy to download the
files. Now this behavior is set by parameter $ignore_proxy
which default to false.

Without this its not possible to download files without proxy when a
system proxy is set.
